### PR TITLE
Update env_file reference in docker-compose.yml to use .env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     environment:
       GENERATE_SETTINGS: true
     env_file:
-      - .env.example
+      - .env
     volumes:
       - ./server-files:/project-zomboid
       - ./server-data:/project-zomboid-config


### PR DESCRIPTION
## Context

IMO, the docker compose should use the real `.env`, not the `.env.example`.

## Choices

## Test instructions

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the readme.md.
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
