### PR TITLE
Fix spawn settings being overwritten

### DIFF
--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -146,14 +146,14 @@ export ANTI_CHEAT_PROTECTION_TYPE20_THRESHOLD_MULTIPLIER=${ANTI_CHEAT_PROTECTION
 export ANTI_CHEAT_PROTECTION_TYPE22_THRESHOLD_MULTIPLIER=${ANTI_CHEAT_PROTECTION_TYPE22_THRESHOLD_MULTIPLIER:-1.0}
 export ANTI_CHEAT_PROTECTION_TYPE24_THRESHOLD_MULTIPLIER=${ANTI_CHEAT_PROTECTION_TYPE24_THRESHOLD_MULTIPLIER:-6.0}
 
-cat > "/project-zomboid-config/Server/${SERVER_NAME}.ini" <<EOF
-$(envsubst < /home/steam/server/templates/settings.ini.template)
+cat >"/project-zomboid-config/Server/${SERVER_NAME}.ini" <<EOF
+$(envsubst </home/steam/server/templates/settings.ini.template)
 EOF
 
-if ! [ -f "${SERVER_NAME}_spawnpoints.lua" ]; then
-    cp /home/steam/server/templates/server_spawnpoints.lua.template "/project-zomboid-config/Server/${SERVER_NAME}_spawnpoints.lua"
+if ! [ -f "$config_dir/${SERVER_NAME}_spawnpoints.lua" ]; then
+  cp /home/steam/server/templates/server_spawnpoints.lua.template "/project-zomboid-config/Server/${SERVER_NAME}_spawnpoints.lua"
 fi
 
-if ! [ -f "${SERVER_NAME}_spawnregions.lua" ]; then
-    cp /home/steam/server/templates/server_spawnregions.lua.template "/project-zomboid-config/Server/${SERVER_NAME}_spawnregions.lua"
+if ! [ -f "$config_dir/${SERVER_NAME}_spawnregions.lua" ]; then
+  cp /home/steam/server/templates/server_spawnregions.lua.template "/project-zomboid-config/Server/${SERVER_NAME}_spawnregions.lua"
 fi


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
This fixes an issue I encountered where my additions to the spawnregions file were not persisting

## Choices

It seemed logical and almost like maybe it was forgotten / mistaken :sweat_smile: 

## Test instructions

1. Edit the generated spawnregions file
2. Start your container
3. Observe that the changes made persist

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [x] I've added documentation about this change to the readme.md.
- [x] I've not introduced breaking changes.
- [x] My changes do not violate linting rules.
