### PR TITLE
Fixes for overwritten configs, container build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,55 +11,55 @@ SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
 ENV CGO_ENABLED=0
 RUN wget -q https://github.com/gorcon/rcon-cli/archive/refs/tags/v${RCON_VERSION}.tar.gz -O rcon.tar.gz \
-    && echo "${RCON_TGZ_SHA1SUM}" rcon.tar.gz | sha1sum -c - \
-    && tar -xzvf rcon.tar.gz \
-    && rm rcon.tar.gz \
-    && mv rcon-cli-${RCON_VERSION}/* ./ \
-    && rm -rf rcon-cli-${RCON_VERSION} \
-    && go build -v ./cmd/gorcon
+  && echo "${RCON_TGZ_SHA1SUM}" rcon.tar.gz | sha1sum -c - \
+  && tar -xzvf rcon.tar.gz \
+  && rm rcon.tar.gz \
+  && mv rcon-cli-${RCON_VERSION}/* ./ \
+  && rm -rf rcon-cli-${RCON_VERSION} \
+  && go build -v ./cmd/gorcon
 
 #BUILD THE SERVER IMAGE
 FROM cm2network/steamcmd:root
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gettext-base=0.21-12 \
-    procps=2:4.0.2-3 \
-    jq=1.6-2.1+deb12u1 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+  gettext-base \
+  procps \
+  jq \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=rcon-cli_builder /build/gorcon /usr/bin/rcon-cli
 
 LABEL maintainer="support@indifferentbroccoli.com" \
-      name="indifferentbroccoli/projectzomboid-server-docker" \
-      github="https://github.com/indifferentbroccoli/projectzomboid-server-docker" \
-      dockerhub="https://hub.docker.com/r/indifferentbroccoli/projectzomboid-server-docker"
+  name="indifferentbroccoli/projectzomboid-server-docker" \
+  github="https://github.com/indifferentbroccoli/projectzomboid-server-docker" \
+  dockerhub="https://hub.docker.com/r/indifferentbroccoli/projectzomboid-server-docker"
 
 ENV HOME=/home/steam \
-    CONFIG_DIR=/project-zomboid-config \
-    ADMIN_USERNAME=admin \
-    ADMIN_PASSWORD=admin \
-    DEFAULT_PORT=16261 \
-    UDP_PORT=16262 \
-    RCON_PORT=27015 \
-    SERVER_NAME=pzserver \
-    STEAM_VAC=true \
-    USE_STEAM=true \
-    GENERATE_SETTINGS=true \
-    SERVER_BRANCH="" \
-    MEMORY_XMX_GB=8 \
-    MEMORY_XMS_GB=""
+  CONFIG_DIR=/project-zomboid-config \
+  ADMIN_USERNAME=admin \
+  ADMIN_PASSWORD=admin \
+  DEFAULT_PORT=16261 \
+  UDP_PORT=16262 \
+  RCON_PORT=27015 \
+  SERVER_NAME=pzserver \
+  STEAM_VAC=true \
+  USE_STEAM=true \
+  GENERATE_SETTINGS=true \
+  SERVER_BRANCH="" \
+  MEMORY_XMX_GB=8 \
+  MEMORY_XMS_GB=""
 
 COPY ./scripts /home/steam/server/
 
 COPY branding /branding
 
 RUN mkdir -p /project-zomboid /project-zomboid-config && \
-    chmod +x /home/steam/server/*.sh
+  chmod +x /home/steam/server/*.sh
 
 WORKDIR /home/steam/server
 
 HEALTHCHECK --start-period=5m \
-            CMD pgrep "ProjectZomboid" > /dev/null || exit 1
+  CMD pgrep "ProjectZomboid" > /dev/null || exit 1
 
 ENTRYPOINT ["/home/steam/server/init.sh"]

--- a/scripts/compile-settings.sh
+++ b/scripts/compile-settings.sh
@@ -146,14 +146,14 @@ export ANTI_CHEAT_PROTECTION_TYPE20_THRESHOLD_MULTIPLIER=${ANTI_CHEAT_PROTECTION
 export ANTI_CHEAT_PROTECTION_TYPE22_THRESHOLD_MULTIPLIER=${ANTI_CHEAT_PROTECTION_TYPE22_THRESHOLD_MULTIPLIER:-1.0}
 export ANTI_CHEAT_PROTECTION_TYPE24_THRESHOLD_MULTIPLIER=${ANTI_CHEAT_PROTECTION_TYPE24_THRESHOLD_MULTIPLIER:-6.0}
 
-cat > "/project-zomboid-config/Server/${SERVER_NAME}.ini" <<EOF
-$(envsubst < /home/steam/server/templates/settings.ini.template)
+cat >"/project-zomboid-config/Server/${SERVER_NAME}.ini" <<EOF
+$(envsubst </home/steam/server/templates/settings.ini.template)
 EOF
 
-if ! [ -f "${SERVER_NAME}_spawnpoints.lua" ]; then
-    cp /home/steam/server/templates/server_spawnpoints.lua.template "/project-zomboid-config/Server/${SERVER_NAME}_spawnpoints.lua"
+if ! [ -f "$config_dir/${SERVER_NAME}_spawnpoints.lua" ]; then
+  cp /home/steam/server/templates/server_spawnpoints.lua.template "/project-zomboid-config/Server/${SERVER_NAME}_spawnpoints.lua"
 fi
 
-if ! [ -f "${SERVER_NAME}_spawnregions.lua" ]; then
-    cp /home/steam/server/templates/server_spawnregions.lua.template "/project-zomboid-config/Server/${SERVER_NAME}_spawnregions.lua"
+if ! [ -f "$config_dir/${SERVER_NAME}_spawnregions.lua" ]; then
+  cp /home/steam/server/templates/server_spawnregions.lua.template "/project-zomboid-config/Server/${SERVER_NAME}_spawnregions.lua"
 fi


### PR DESCRIPTION
## Context <!-- markdownlint-disable MD041 -->
<!-- If applicable, this fixes the following issues: -->
Fixes #40 
<!-- What do you want to achieve with this PR? -->
Fix configs being overwritten, fix critical build issue
## Choices

<!-- * Why did you solve it like this? -->
Version pinning is not tracking upstream container images. There is an issue currently:
```
[2/2] STEP 2/11: RUN apt-get update && apt-get install -y --no-install-recommends     gettext-base=0.21-12     procps=2:4.0.2-3     jq=1.6-2.1+deb12u1     && apt-get clean     && rm -rf /var/lib/apt/lists/*
Get:1 http://deb.debian.org/debian trixie InRelease [140 kB]
Get:2 http://deb.debian.org/debian trixie-updates InRelease [47.3 kB]
Get:3 http://deb.debian.org/debian-security trixie-security InRelease [43.4 kB]
Get:4 http://deb.debian.org/debian trixie/main amd64 Packages [9670 kB]
Get:5 http://deb.debian.org/debian trixie-updates/main amd64 Packages [5412 B]
Get:6 http://deb.debian.org/debian-security trixie-security/main amd64 Packages [108 kB]
Fetched 10.0 MB in 2s (4323 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
Package procps is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libproc2-0

Package jq is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

Package gettext-base is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libasprintf0v5

E: Version '0.21-12' for 'gettext-base' was not found
E: Version '2:4.0.2-3' for 'procps' was not found
E: Version '1.6-2.1+deb12u1' for 'jq' was not found
Error: building at STEP "RUN apt-get update && apt-get install -y --no-install-recommends     gettext-base=0.21-12     procps=2:4.0.2-3     jq=1.6-2.1+deb12u1     && apt-get clean     && rm -rf /var/lib/apt/lists/*": while running runtime: exit status 100
```

Either we stop pinning the package versions (less reproducible) or we start pinning the Debian release.

## Test instructions

1. <!-- 1. How did you test this PR? -->
I was successfully able to build the container, and observe my original fix did not overwrite my configs when starting my server(s)

## Checklist before requesting a review

- [x] I have performed a self-review/test of my code
- [ ] I've added documentation about this change to the readme.md.
- [x] I've not introduced breaking changes.
- [?] My changes do not violate linting rules.
